### PR TITLE
updates React.createClass and PropTypes syntax to remove deprecation warnings

### DIFF
--- a/index.js
+++ b/index.js
@@ -5,6 +5,7 @@
 'use strict';
 
 var React = require('react');
+var PropTypes = require('prop-types');
 
 module.exports = function getContextProviderCurried(context, children) {
   if (typeof children === 'undefined') {
@@ -17,19 +18,25 @@ module.exports = function getContextProviderCurried(context, children) {
 };
 
 function getContextProvider(context, children) {
-  var ContextProvider = React.createClass({
-    displayName: 'ContextProvider',
-
-    getChildContext: function getChildContext() {
-      return context;
-    },
-    childContextTypes: Object.keys(context).reduce(function (obj, key) {
-      obj[key] = React.PropTypes.any;
+  function childContextTypes() {
+    return Object.keys(context).reduce(function(obj, key) {
+      obj[key] = PropTypes.any;
       return obj;
-    }, {}),
-    render: function render() {
+    }, {});
+  }
+
+  class ContextProvider extends React.Component {
+    getChildContext() {
+      return context;
+    }
+
+    render() {
       return children;
     }
-  });
+  }
+
+  ContextProvider.displayName = 'ContextProvider';
+  ContextProvider.childContextTypes = childContextTypes();
+
   return React.createElement(ContextProvider, null);
-};
+}


### PR DESCRIPTION
Hey, Kent! 👋 

I was using this lib (which works great, thanks!), and I saw some deprecation warnings for using `createClass` and `React.PropTypes`:

```sh
  console.warn node_modules/react/lib/lowPriorityWarning.js:38
    Warning: Accessing createClass via the main React package is deprecated, and will be removed in React v16.0. Use a plain JavaScript class instead. If you're not yet ready to migrate, create-react-class v15.* is available on npm as a temporary, drop-in replacement. For more info see https://fb.me/react-create-class

  console.warn node_modules/react/lib/lowPriorityWarning.js:38
    Warning: Accessing PropTypes via the main React package is deprecated, and will be removed in  React v16.0. Use the latest available v15.* prop-types package from npm instead. For info on usage, compatibility, migration and more, see https://fb.me/prop-types-docs
```

So, I thought I'd submit a PR to update the syntax. 😄 I tried to change as little as possible. Let me know if you'd like me to update anything else though. I didn't bump the version, as I thought you might want to do that.

Cheers and thanks again for the lib!
